### PR TITLE
Update owncloud url

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -122,7 +122,7 @@ steps:
     settings:
       webhook:
         from_secret: private_rocketchat
-      channel: desktop-client-builds
+      channel: builds
 
 depends_on:
   - matrix-1
@@ -131,7 +131,6 @@ trigger:
   ref:
     - refs/tags/**
     - refs/heads/master
-    - refs/pull/**
   status:
     - success
     - failure

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,7 @@ pipeline:
       - tar -jxf owncloud-${SERVER_VERSION}.tar.bz2 -C /var/www
 
   owncloud-server:
-    image: owncloud/base:bionic
+    image: owncloudci/php:7.4
     pull: true
     detach: true
     environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -62,12 +62,16 @@ steps:
     commands:
       - wait-for -it server:80 -t 600
 
+  - name: setup-server
+    image: owncloudci/php:7.4
+    commands:
+      - cd /var/www/owncloud/server
+      - php occ config:system:set trusted_domains 1 --value=server
+
   - name: fix-permissions
     image: owncloudci/php:7.4
     commands:
-      - ls -al  /var/www/owncloud/server
       - chown -R www-data /var/www/owncloud/server
-      - ls -al  /var/www/owncloud/server
 
   - name: owncloud-log
     image: owncloud/ubuntu:20.04

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,112 +15,112 @@ steps:
 trigger:
   ref:
     - refs/pull/**
-# ---
-# {
-#   'kind': 'pipeline',
-#   'type': 'docker',
-#   'name': 'matrix-1',
-#   'workspace': { 'base': '/var/www/owncloud' },
-#   'services':
-#     [
-#       {
-#         'name': 'server',
-#         'image': 'owncloudci/php:7.4',
-#         'environment':
-#           {
-#             'APACHE_WEBROOT': '/var/www/owncloud/server',
-#             'APACHE_LOGGING_PATH': '/dev/null',
-#           },
-#         'commands': ['/usr/local/bin/apachectl -e debug -D FOREGROUND'],
-#       },
-#       {
-#         'name': 'mysql',
-#         'image': 'mysql',
-#         'environment':
-#           {
-#             'MYSQL_USER': 'owncloud',
-#             'MYSQL_PASSWORD': 'owncloud',
-#             'MYSQL_DATABASE': 'owncloud',
-#             'MYSQL_ROOT_PASSWORD': 'owncloud',
-#           },
-#         'command': ['--default-authentication-plugin=mysql_native_password'],
-#       },
-#     ],
-#   'steps':
-#     [
-#       {
-#         'name': 'install-core',
-#         'image': 'owncloudci/core',
-#         'settings':
-#           {
-#             'version': 'daily-master',
-#             'core_path': '/var/www/owncloud/server',
-#             'db_type': 'mysql',
-#             'db_name': 'owncloud',
-#             'db_host': 'mysql',
-#             'db_username': 'owncloud',
-#             'db_password': 'owncloud',
-#           },
-#       },
-#       {
-#         'name': 'wait-for-server',
-#         'image': 'owncloudci/wait-for:latest',
-#         'commands': ['wait-for -it server:80 -t 600'],
-#       },
-#       {
-#         'name': 'owncloud-log',
-#         'image': 'owncloud/ubuntu:20.04',
-#         'detach': true,
-#         'commands': ['tail -f /var/www/owncloud/server/data/owncloud.log'],
-#       },
-#       {
-#         'name': 'litmus-old-api',
-#         'image': 'owncloud/litmus:latest',
-#         'environment':
-#           {
-#             'LITMUS_PASSWORD': 'admin',
-#             'LITMUS_USERNAME': 'admin',
-#             'LITMUS_URL': 'http://server:80/remote.php/webdav',
-#           },
-#         'commands': ['litmus-wrapper'],
-#       },
-#       {
-#         'name': 'litmus-new-api',
-#         'image': 'owncloud/litmus:latest',
-#         'environment':
-#           {
-#             'LITMUS_PASSWORD': 'admin',
-#             'LITMUS_USERNAME': 'admin',
-#             'LITMUS_URL': 'http://server:80/remote.php/dav/files/admin',
-#           },
-#         'commands': ['litmus-wrapper'],
-#       },
-#     ],
-#   'depends_on': ['cancel-previous-builds'],
-#   'trigger': { 'ref': ['refs/tags/**', 'refs/heads/master', 'refs/pull/**'] },
-# }
-# ---
-# {
-#   'kind': 'pipeline',
-#   'type': 'docker',
-#   'name': 'chat-notifications',
-#   'clone': { 'disable': true },
-#   'steps':
-#     [
-#       {
-#         'name': 'notify-rocketchat',
-#         'image': 'plugins/slack:1',
-#         'settings':
-#           {
-#             'webhook': { 'from_secret': 'private_rocketchat' },
-#             'channel': 'desktop-client-builds',
-#           },
-#       },
-#     ],
-#   'depends_on': ['matrix-1'],
-#   'trigger':
-#     {
-#       'ref': ['refs/tags/**', 'refs/heads/master', 'refs/pull/**'],
-#       'status': ['success', 'failure'],
-#     },
-# }
+
+#
+# Litmus tests
+#
+---
+kind: pipeline
+type: docker
+name: matrix-1
+workspace:
+  base: /var/www/owncloud
+
+services:
+  - name: server
+    image: owncloudci/php:7.4
+    environment:
+      APACHE_WEBROOT: /var/www/owncloud/server
+      APACHE_LOGGING_PATH: /dev/null
+    commands:
+      - /usr/local/bin/apachectl -e debug -D FOREGROUND
+
+  - name: mysql
+    image: mysql
+    environment:
+      MYSQL_USER: owncloud
+      MYSQL_PASSWORD: owncloud
+      MYSQL_DATABASE: owncloud
+      MYSQL_ROOT_PASSWORD: owncloud
+    command:
+      - --default-authentication-plugin=mysql_native_password
+
+steps:
+  - name: install-core
+    image: owncloudci/core
+    settings:
+      version: daily-master
+      core_path: /var/www/owncloud/server
+      db_type: mysql
+      db_name: owncloud
+      db_host: mysql
+      db_username: owncloud
+      db_password: owncloud
+
+  - name: wait-for-server
+    image: owncloudci/wait-for:latest
+    commands:
+      - wait-for -it server:80 -t 600
+
+  - name: owncloud-log
+    image: owncloud/ubuntu:20.04
+    detach: true
+    commands:
+      - tail -f /var/www/owncloud/server/data/owncloud.log
+
+  - name: litmus-old-api
+    image: owncloud/litmus:latest
+    environment:
+      LITMUS_PASSWORD: admin
+      LITMUS_USERNAME: admin
+      LITMUS_URL: http://server:80/remote.php/webdav
+    commands:
+      - litmus-wrapper
+
+  - name: litmus-new-api
+    image: owncloud/litmus:latest
+    environment:
+      LITMUS_PASSWORD: admin
+      LITMUS_USERNAME: admin
+      LITMUS_URL': http://server:80/remote.php/dav/files/admin
+    commands:
+      - litmus-wrapper
+
+depends_on:
+  - cancel-previous-builds
+
+trigger:
+  ref:
+    - refs/tags/**
+    - refs/heads/master
+    - refs/pull/**
+
+#
+# Rocket-caht Notification
+#
+---
+kind: pipeline
+type: docker
+name: chat-notifications
+clone:
+  disable: true
+
+steps:
+  - name: notify-rocketchat
+    image: plugins/slack:1
+    settings:
+      webhook:
+        from_secret: private_rocketchat
+      channel: desktop-client-builds
+
+depends_on:
+  - matrix-1
+
+trigger:
+  ref:
+    - refs/tags/**
+    - refs/heads/master
+    - refs/pull/**
+  status:
+    - success
+    - failure

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,32 +11,18 @@ clone:
     pull: true
 
 pipeline:
-  owncloud-download:
-    image: plugins/download:1
-    pull: true
-    source: https://download.owncloud.com/server/daily/owncloud-${SERVER_VERSION}.tar.bz2
-
-  owncloud-unpack:
-    image: owncloud/ubuntu:latest
-    pull: true
-    commands:
-      - tar -jxf owncloud-${SERVER_VERSION}.tar.bz2 -C /var/www
-
   owncloud-server:
-    image: owncloudci/php:7.4
+    image: owncloudci/core
     pull: true
     detach: true
-    environment:
-      - OWNCLOUD_DOMAIN=owncloud-server
-      - OWNCLOUD_DB_TYPE=mysql
-      - OWNCLOUD_DB_NAME=owncloud
-      - OWNCLOUD_DB_USERNAME=owncloud
-      - OWNCLOUD_DB_PASSWORD=owncloud
-      - OWNCLOUD_DB_HOST=mysql
-      - OWNCLOUD_REDIS_ENABLED=true
-      - OWNCLOUD_REDIS_HOST=redis
-      - OWNCLOUD_ADMIN_USERNAME=admin
-      - OWNCLOUD_ADMIN_PASSWORD=admin
+    settings:
+      version: ${SERVER_VERSION}
+      core_path: /var/www
+      db_type: mysql
+      db_name: owncloud
+      db_host: mysql
+      db_username: owncloud
+      db_password: owncloud
 
   owncloud-waiting:
     image: owncloud/ubuntu:latest
@@ -67,13 +53,13 @@ pipeline:
   notify-rocketchat:
     image: plugins/slack:1
     pull: true
-    secrets: [ slack_webhook ]
+    secrets: [slack_webhook]
     channel: litmus
     template: >
       *{{build.status}}* <{{build.link}}|{{repo.owner}}/{{repo.name}}#{{truncate build.commit 8}}> basic:litmus:${SERVER_VERSION}:general
     when:
       local: false
-      status: [ changed, failure ]
+      status: [changed, failure]
 
 services:
   mysql:

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ pipeline:
   owncloud-download:
     image: plugins/download:1
     pull: true
-    source: https://download.owncloud.org/community/owncloud-${SERVER_VERSION}.tar.bz2
+    source: https://download.owncloud.com/server/daily/owncloud-${SERVER_VERSION}.tar.bz2
 
   owncloud-unpack:
     image: owncloud/ubuntu:latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,81 +1,125 @@
-workspace:
-  base: /var/www
-  path:
-
-branches:
-  - master
-
-clone:
-  git:
-    image: plugins/git:1
-    pull: true
-
-pipeline:
-  owncloud-server:
-    image: owncloudci/core
-    pull: true
-    detach: true
-    settings:
-      version: ${SERVER_VERSION}
-      core_path: /var/www
-      db_type: mysql
-      db_name: owncloud
-      db_host: mysql
-      db_username: owncloud
-      db_password: owncloud
-
-  owncloud-waiting:
-    image: owncloud/ubuntu:latest
-    pull: true
-    commands:
-      - wait-for-it -t 300 owncloud-server:8080
-
-  litmus-oldapi:
-    image: owncloud/litmus:${LITMUS_VERSION}
-    pull: true
-    environment:
-      - LITMUS_URL=http://owncloud-server:8080/remote.php/webdav
-      - LITMUS_USERNAME=admin
-      - LITMUS_PASSWORD=admin
-    commands:
-      - litmus-wrapper
-
-  litmus-newapi:
-    image: owncloud/litmus:${LITMUS_VERSION}
-    pull: true
-    environment:
-      - LITMUS_URL=http://owncloud-server:8080/remote.php/dav/files/admin
-      - LITMUS_USERNAME=admin
-      - LITMUS_PASSWORD=admin
-    commands:
-      - litmus-wrapper
-
-  notify-rocketchat:
-    image: plugins/slack:1
-    pull: true
-    secrets: [slack_webhook]
-    channel: litmus
-    template: >
-      *{{build.status}}* <{{build.link}}|{{repo.owner}}/{{repo.name}}#{{truncate build.commit 8}}> basic:litmus:${SERVER_VERSION}:general
-    when:
-      local: false
-      status: [changed, failure]
-
-services:
-  mysql:
-    image: library/mariadb:10.3
-    pull: true
-    environment:
-      - MYSQL_USER=owncloud
-      - MYSQL_PASSWORD=owncloud
-      - MYSQL_DATABASE=owncloud
-      - MYSQL_ROOT_PASSWORD=owncloud
-
-  redis:
-    image: library/redis:4.0
-    pull: true
-
-matrix:
-  include:
-    - LITMUS_VERSION: latest
-      SERVER_VERSION: daily-master
+---
+{
+  'kind': 'pipeline',
+  'type': 'docker',
+  'name': 'cancel-previous-builds',
+  'clone': { 'disable': true },
+  'steps':
+    [
+      {
+        'name': 'cancel-previous-builds',
+        'image': 'owncloudci/drone-cancel-previous-builds',
+        'settings': { 'DRONE_TOKEN': { 'from_secret': 'drone_token' } },
+      },
+    ],
+  'trigger': { 'ref': ['refs/pull/**'] },
+}
+---
+{
+  'kind': 'pipeline',
+  'type': 'docker',
+  'name': 'matrix-1',
+  'workspace': { 'base': '/var/www/owncloud' },
+  'services':
+    [
+      {
+        'name': 'server',
+        'image': 'owncloudci/php:7.4',
+        'environment':
+          {
+            'APACHE_WEBROOT': '/var/www/owncloud/server',
+            'APACHE_LOGGING_PATH': '/dev/null',
+          },
+        'commands': ['/usr/local/bin/apachectl -e debug -D FOREGROUND'],
+      },
+      {
+        'name': 'mysql',
+        'image': 'mysql',
+        'environment':
+          {
+            'MYSQL_USER': 'owncloud',
+            'MYSQL_PASSWORD': 'owncloud',
+            'MYSQL_DATABASE': 'owncloud',
+            'MYSQL_ROOT_PASSWORD': 'owncloud',
+          },
+        'command': ['--default-authentication-plugin=mysql_native_password'],
+      },
+    ],
+  'steps':
+    [
+      {
+        'name': 'install-core',
+        'image': 'owncloudci/core',
+        'settings':
+          {
+            'version': 'daily-master',
+            'core_path': '/var/www/owncloud/server',
+            'db_type': 'mysql',
+            'db_name': 'owncloud',
+            'db_host': 'mysql',
+            'db_username': 'owncloud',
+            'db_password': 'owncloud',
+          },
+      },
+      {
+        'name': 'wait-for-server',
+        'image': 'owncloudci/wait-for:latest',
+        'commands': ['wait-for -it server:80 -t 600'],
+      },
+      {
+        'name': 'owncloud-log',
+        'image': 'owncloud/ubuntu:20.04',
+        'detach': true,
+        'commands': ['tail -f /var/www/owncloud/server/data/owncloud.log'],
+      },
+      {
+        'name': 'litmus-old-api',
+        'image': 'owncloud/litmus:latest',
+        'environment':
+          {
+            'LITMUS_PASSWORD': 'admin',
+            'LITMUS_USERNAME': 'admin',
+            'LITMUS_URL': 'http://server:80/remote.php/webdav',
+          },
+        'commands': ['litmus-wrapper'],
+      },
+      {
+        'name': 'litmus-new-api',
+        'image': 'owncloud/litmus:latest',
+        'environment':
+          {
+            'LITMUS_PASSWORD': 'admin',
+            'LITMUS_USERNAME': 'admin',
+            'LITMUS_URL': 'http://server:80/remote.php/dav/files/admin',
+          },
+        'commands': ['litmus-wrapper'],
+      },
+    ],
+  'depends_on': ['cancel-previous-builds'],
+  'trigger': { 'ref': ['refs/tags/**', 'refs/heads/master', 'refs/pull/**'] },
+}
+---
+{
+  'kind': 'pipeline',
+  'type': 'docker',
+  'name': 'chat-notifications',
+  'clone': { 'disable': true },
+  'steps':
+    [
+      {
+        'name': 'notify-rocketchat',
+        'image': 'plugins/slack:1',
+        'settings':
+          {
+            'webhook': { 'from_secret': 'private_rocketchat' },
+            'channel': 'desktop-client-builds',
+          },
+      },
+    ],
+  'depends_on': ['matrix-1'],
+  'trigger':
+    {
+      'ref': ['refs/tags/**', 'refs/heads/master', 'refs/pull/**'],
+      'status': ['success', 'failure'],
+    },
+}

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,125 +1,126 @@
 ---
-{
-  'kind': 'pipeline',
-  'type': 'docker',
-  'name': 'cancel-previous-builds',
-  'clone': { 'disable': true },
-  'steps':
-    [
-      {
-        'name': 'cancel-previous-builds',
-        'image': 'owncloudci/drone-cancel-previous-builds',
-        'settings': { 'DRONE_TOKEN': { 'from_secret': 'drone_token' } },
-      },
-    ],
-  'trigger': { 'ref': ['refs/pull/**'] },
-}
----
-{
-  'kind': 'pipeline',
-  'type': 'docker',
-  'name': 'matrix-1',
-  'workspace': { 'base': '/var/www/owncloud' },
-  'services':
-    [
-      {
-        'name': 'server',
-        'image': 'owncloudci/php:7.4',
-        'environment':
-          {
-            'APACHE_WEBROOT': '/var/www/owncloud/server',
-            'APACHE_LOGGING_PATH': '/dev/null',
-          },
-        'commands': ['/usr/local/bin/apachectl -e debug -D FOREGROUND'],
-      },
-      {
-        'name': 'mysql',
-        'image': 'mysql',
-        'environment':
-          {
-            'MYSQL_USER': 'owncloud',
-            'MYSQL_PASSWORD': 'owncloud',
-            'MYSQL_DATABASE': 'owncloud',
-            'MYSQL_ROOT_PASSWORD': 'owncloud',
-          },
-        'command': ['--default-authentication-plugin=mysql_native_password'],
-      },
-    ],
-  'steps':
-    [
-      {
-        'name': 'install-core',
-        'image': 'owncloudci/core',
-        'settings':
-          {
-            'version': 'daily-master',
-            'core_path': '/var/www/owncloud/server',
-            'db_type': 'mysql',
-            'db_name': 'owncloud',
-            'db_host': 'mysql',
-            'db_username': 'owncloud',
-            'db_password': 'owncloud',
-          },
-      },
-      {
-        'name': 'wait-for-server',
-        'image': 'owncloudci/wait-for:latest',
-        'commands': ['wait-for -it server:80 -t 600'],
-      },
-      {
-        'name': 'owncloud-log',
-        'image': 'owncloud/ubuntu:20.04',
-        'detach': true,
-        'commands': ['tail -f /var/www/owncloud/server/data/owncloud.log'],
-      },
-      {
-        'name': 'litmus-old-api',
-        'image': 'owncloud/litmus:latest',
-        'environment':
-          {
-            'LITMUS_PASSWORD': 'admin',
-            'LITMUS_USERNAME': 'admin',
-            'LITMUS_URL': 'http://server:80/remote.php/webdav',
-          },
-        'commands': ['litmus-wrapper'],
-      },
-      {
-        'name': 'litmus-new-api',
-        'image': 'owncloud/litmus:latest',
-        'environment':
-          {
-            'LITMUS_PASSWORD': 'admin',
-            'LITMUS_USERNAME': 'admin',
-            'LITMUS_URL': 'http://server:80/remote.php/dav/files/admin',
-          },
-        'commands': ['litmus-wrapper'],
-      },
-    ],
-  'depends_on': ['cancel-previous-builds'],
-  'trigger': { 'ref': ['refs/tags/**', 'refs/heads/master', 'refs/pull/**'] },
-}
----
-{
-  'kind': 'pipeline',
-  'type': 'docker',
-  'name': 'chat-notifications',
-  'clone': { 'disable': true },
-  'steps':
-    [
-      {
-        'name': 'notify-rocketchat',
-        'image': 'plugins/slack:1',
-        'settings':
-          {
-            'webhook': { 'from_secret': 'private_rocketchat' },
-            'channel': 'desktop-client-builds',
-          },
-      },
-    ],
-  'depends_on': ['matrix-1'],
-  'trigger':
-    {
-      'ref': ['refs/tags/**', 'refs/heads/master', 'refs/pull/**'],
-      'status': ['success', 'failure'],
-    },
-}
+kind: pipeline
+type: docker
+name: cancel-previous-builds
+clone:
+  disable: true
+
+steps:
+  - name: cancel-previous-builds
+    image: owncloudci/drone-cancel-previous-builds
+    settings:
+      DRONE_TOKEN:
+        from_secret: drone_token
+
+trigger:
+  ref:
+    - refs/pull/**
+# ---
+# {
+#   'kind': 'pipeline',
+#   'type': 'docker',
+#   'name': 'matrix-1',
+#   'workspace': { 'base': '/var/www/owncloud' },
+#   'services':
+#     [
+#       {
+#         'name': 'server',
+#         'image': 'owncloudci/php:7.4',
+#         'environment':
+#           {
+#             'APACHE_WEBROOT': '/var/www/owncloud/server',
+#             'APACHE_LOGGING_PATH': '/dev/null',
+#           },
+#         'commands': ['/usr/local/bin/apachectl -e debug -D FOREGROUND'],
+#       },
+#       {
+#         'name': 'mysql',
+#         'image': 'mysql',
+#         'environment':
+#           {
+#             'MYSQL_USER': 'owncloud',
+#             'MYSQL_PASSWORD': 'owncloud',
+#             'MYSQL_DATABASE': 'owncloud',
+#             'MYSQL_ROOT_PASSWORD': 'owncloud',
+#           },
+#         'command': ['--default-authentication-plugin=mysql_native_password'],
+#       },
+#     ],
+#   'steps':
+#     [
+#       {
+#         'name': 'install-core',
+#         'image': 'owncloudci/core',
+#         'settings':
+#           {
+#             'version': 'daily-master',
+#             'core_path': '/var/www/owncloud/server',
+#             'db_type': 'mysql',
+#             'db_name': 'owncloud',
+#             'db_host': 'mysql',
+#             'db_username': 'owncloud',
+#             'db_password': 'owncloud',
+#           },
+#       },
+#       {
+#         'name': 'wait-for-server',
+#         'image': 'owncloudci/wait-for:latest',
+#         'commands': ['wait-for -it server:80 -t 600'],
+#       },
+#       {
+#         'name': 'owncloud-log',
+#         'image': 'owncloud/ubuntu:20.04',
+#         'detach': true,
+#         'commands': ['tail -f /var/www/owncloud/server/data/owncloud.log'],
+#       },
+#       {
+#         'name': 'litmus-old-api',
+#         'image': 'owncloud/litmus:latest',
+#         'environment':
+#           {
+#             'LITMUS_PASSWORD': 'admin',
+#             'LITMUS_USERNAME': 'admin',
+#             'LITMUS_URL': 'http://server:80/remote.php/webdav',
+#           },
+#         'commands': ['litmus-wrapper'],
+#       },
+#       {
+#         'name': 'litmus-new-api',
+#         'image': 'owncloud/litmus:latest',
+#         'environment':
+#           {
+#             'LITMUS_PASSWORD': 'admin',
+#             'LITMUS_USERNAME': 'admin',
+#             'LITMUS_URL': 'http://server:80/remote.php/dav/files/admin',
+#           },
+#         'commands': ['litmus-wrapper'],
+#       },
+#     ],
+#   'depends_on': ['cancel-previous-builds'],
+#   'trigger': { 'ref': ['refs/tags/**', 'refs/heads/master', 'refs/pull/**'] },
+# }
+# ---
+# {
+#   'kind': 'pipeline',
+#   'type': 'docker',
+#   'name': 'chat-notifications',
+#   'clone': { 'disable': true },
+#   'steps':
+#     [
+#       {
+#         'name': 'notify-rocketchat',
+#         'image': 'plugins/slack:1',
+#         'settings':
+#           {
+#             'webhook': { 'from_secret': 'private_rocketchat' },
+#             'channel': 'desktop-client-builds',
+#           },
+#       },
+#     ],
+#   'depends_on': ['matrix-1'],
+#   'trigger':
+#     {
+#       'ref': ['refs/tags/**', 'refs/heads/master', 'refs/pull/**'],
+#       'status': ['success', 'failure'],
+#     },
+# }

--- a/.drone.yml
+++ b/.drone.yml
@@ -62,6 +62,13 @@ steps:
     commands:
       - wait-for -it server:80 -t 600
 
+  - name: fix-permissions
+    image: owncloudci/php:7.4
+    commands:
+      - ls -al  /var/www/owncloud/server
+      - chown -R www-data /var/www/owncloud/server
+      - ls -al  /var/www/owncloud/server
+
   - name: owncloud-log
     image: owncloud/ubuntu:20.04
     detach: true
@@ -82,7 +89,7 @@ steps:
     environment:
       LITMUS_PASSWORD: admin
       LITMUS_USERNAME: admin
-      LITMUS_URL': http://server:80/remote.php/dav/files/admin
+      LITMUS_URL: http://server:80/remote.php/dav/files/admin
     commands:
       - litmus-wrapper
 


### PR DESCRIPTION
Now, `download.owncloud.org` is redirected to `download.owncloud.com`. And the new location for the daily tarballs is in `https://download.owncloud.com/server/daily/`

Fixes #7, #9

Tasks:
- [x] litmus tests
- [x] notification