### PR TITLE
chore: update litmus to maintained container

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,7 +80,7 @@ steps:
       - tail -f /var/www/owncloud/server/data/owncloud.log
 
   - name: litmus-old-api
-    image: owncloud/litmus:latest
+    image: owncloudci/litmus
     environment:
       LITMUS_PASSWORD: admin
       LITMUS_USERNAME: admin
@@ -89,7 +89,7 @@ steps:
       - litmus-wrapper
 
   - name: litmus-new-api
-    image: owncloud/litmus:latest
+    image: owncloudci/litmus
     environment:
       LITMUS_PASSWORD: admin
       LITMUS_USERNAME: admin


### PR DESCRIPTION
The `owncloud/litmus` container is unmaintained and will be removed soon. This PR switches to the new maintained `owncloudci/litmus` container, which was also updates to limus 0.14. If you encounter any issue, please let me know. 