### PR TITLE
Update rocketchat secret

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,25 +1,7 @@
 ---
-kind: pipeline
-type: docker
-name: cancel-previous-builds
-clone:
-  disable: true
-
-steps:
-  - name: cancel-previous-builds
-    image: owncloudci/drone-cancel-previous-builds
-    settings:
-      DRONE_TOKEN:
-        from_secret: drone_token
-
-trigger:
-  ref:
-    - refs/pull/**
-
 #
 # Litmus tests
 #
----
 kind: pipeline
 type: docker
 name: matrix-1
@@ -97,9 +79,6 @@ steps:
     commands:
       - litmus-wrapper
 
-depends_on:
-  - cancel-previous-builds
-
 trigger:
   ref:
     - refs/tags/**
@@ -121,7 +100,7 @@ steps:
     image: plugins/slack:1
     settings:
       webhook:
-        from_secret: private_rocketchat
+        from_secret: rocketchat_chat_webhook
       channel: builds
 
 depends_on:


### PR DESCRIPTION
Recently, the secret-key has been changed. This PR changes rocket chat secret `private_rocketchat` to `rocketchat_chat_webhook`