### PR TITLE
[full-ci] [tests-only] Changed rocketchat notifications server

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -100,7 +100,7 @@ steps:
     image: plugins/slack:1
     settings:
       webhook:
-        from_secret: rocketchat_chat_webhook
+        from_secret: rocketchat_talk_webhook
       channel: builds
 
 depends_on:


### PR DESCRIPTION
This PR change the rocketchat notification server `chat` to `talk`.

Part of https://github.com/owncloud/QA/issues/846