### PR TITLE
Replaced deprecated variable `default-authentication-plugin` for `v8.4`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ services:
       MYSQL_DATABASE: owncloud
       MYSQL_ROOT_PASSWORD: owncloud
     command:
-      - --default-authentication-plugin=mysql_native_password
+      - --mysql-native-password=ON
 
 steps:
   - name: install-core


### PR DESCRIPTION
The CI is running with mysql v8.4 and the `default-authentication-plugin` variable is not working so changed command
`--default-authentication-plugin=mysql_native_password` to `--mysql-native-password=ON`

Fixes https://github.com/owncloud/litmus-testing/issues/15